### PR TITLE
chore: scaffold platform packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,37 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Node / Vite artifacts
+node_modules/
+.pnpm-store/
+dist/
+*.tsbuildinfo
+pnpm-lock.yaml
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+packages/browser-extension/.env.local
+apps/ops-dashboard/.env.local
+
+# Browser extension build outputs
+packages/browser-extension/package/*.zip
+packages/browser-extension/build/
+
+# FastAPI / UV environments
+packages/scoring-api/.venv/
+packages/scoring-api/.env
+packages/scoring-api/.coverage
+
+# Model engine generated assets
+packages/model-engine/.venv/
+packages/model-engine/.env
+packages/model-engine/artifacts/
+packages/model-engine/data/
+packages/model-engine/**/*.mar
+packages/model-engine/**/*.pt
+
+# Ops dashboard local state
+apps/ops-dashboard/.env
+apps/ops-dashboard/.vite
+apps/ops-dashboard/coverage/

--- a/apps/ops-dashboard/README.md
+++ b/apps/ops-dashboard/README.md
@@ -1,0 +1,31 @@
+# Ops Dashboard
+
+## Ownership
+- **Team:** Trust & Safety Operations
+- **Primary Maintainer:** Casey Martinez (<cmartinez@phishsentry.internal>)
+
+## Tech Stack
+- React + TypeScript
+- Vite + PNPM tooling
+- Tailwind CSS + Headless UI
+
+## Local Development
+```bash
+pnpm install
+pnpm dev
+```
+
+## Build & QA
+```bash
+pnpm build
+pnpm preview
+pnpm test
+```
+
+## Deployment Targets
+- Netlify app `ops-dashboard` for staging
+- Kubernetes-hosted SSR Node service for production analytics surface
+
+## Contribution Notes
+- Coordinate telemetry schema updates with Browser Extension and Scoring API teams
+- Dashboard roadmap tracked in Jira project `OPSENG`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,32 @@
+# System Architecture Overview
+
+The PhishSentry platform is organized as a set of loosely coupled components that collaborate to detect, score, and surface phishing attempts across customer environments.
+
+## High-Level Flow
+1. **Browser Extension (`packages/browser-extension`)**
+   - Monitors user interactions and page metadata inside customer browsers.
+   - Submits event payloads and suspicious artifacts to the Scoring API over authenticated HTTPS.
+2. **Scoring API (`packages/scoring-api`)**
+   - Receives event payloads from the extension and internal integrations.
+   - Enriches requests with customer configuration and passes structured feature vectors to the Model Engine.
+   - Persists scoring results and case notes to the shared PostgreSQL database.
+3. **Model Engine (`packages/model-engine`)**
+   - Hosts machine-learned models and deterministic rules for phishing detection.
+   - Returns threat scores, recommended actions, and explanation metadata to the Scoring API.
+4. **Ops Dashboard (`apps/ops-dashboard`)**
+   - Presents real-time case data and analytics to Trust & Safety operators.
+   - Consumes Scoring API webhooks and polling endpoints to display investigation queues and trends.
+
+## Operational Considerations
+- All services emit structured logs to the centralized logging pipeline (`Loki + Grafana`).
+- Shared secrets are managed via HashiCorp Vault and injected at deploy time.
+- Deployment pipelines for all components are orchestrated in GitHub Actions with environment-specific gates.
+
+## Data Contracts
+- Event schemas between the Browser Extension and Scoring API are versioned under `docs/schemas` (to be created).
+- The Scoring API ↔ Model Engine contract uses protobuf definitions for low-latency inference calls.
+- Ops Dashboard expects normalized case records and metrics exposed via `/v1/analytics` endpoints on the Scoring API.
+
+## Future Enhancements
+- Evaluate gRPC streaming between the Scoring API and Model Engine to reduce serialization overhead.
+- Expand the Ops Dashboard to support real-time push updates using WebSockets.

--- a/packages/browser-extension/README.md
+++ b/packages/browser-extension/README.md
@@ -1,0 +1,30 @@
+# Browser Extension
+
+## Ownership
+- **Team:** Client Integrations Guild
+- **Primary Maintainer:** Jordan Lee (<jlee@phishsentry.internal>)
+
+## Tech Stack
+- TypeScript + React
+- Vite build tooling
+- WebExtension APIs targeting Chromium-based browsers
+
+## Development Workflow
+```bash
+pnpm install
+pnpm dev
+```
+
+## Build Commands
+```bash
+pnpm build
+pnpm package
+```
+
+## Deployment Targets
+- Chrome Web Store (internal unlisted distribution)
+- Signed bundles for enterprise customers via manual delivery
+
+## Contribution Notes
+- Feature requests and bug reports are tracked in Linear project `EXT`
+- Coordinate release timelines with the Ops Dashboard team for analytics schema changes

--- a/packages/model-engine/README.md
+++ b/packages/model-engine/README.md
@@ -1,0 +1,31 @@
+# Model Engine
+
+## Ownership
+- **Team:** Applied Research
+- **Primary Maintainer:** Dr. Elena Sorenson (<esorenson@phishsentry.internal>)
+
+## Tech Stack
+- Python 3.11
+- TorchServe for model inference
+- Feature rules executed via Pandas + custom DSL
+
+## Local Development
+```bash
+uv sync
+uv run poe prepare-data
+uv run poe train
+```
+
+## Build & Release
+```bash
+uv run poe package-model  # produces model archive (*.mar)
+uv run poe build-docker   # builds inference image with TorchServe
+```
+
+## Deployment Targets
+- Model artifacts stored in S3 bucket `phishsentry-models`
+- Deployed to Kubernetes `model-engine` deployment behind the Scoring API
+
+## Contribution Notes
+- Coordinate feature engineering changes with the Scoring API team to ensure feature availability
+- Keep `MODEL_VERSION` synchronized with Ops Dashboard analytics expectations

--- a/packages/scoring-api/README.md
+++ b/packages/scoring-api/README.md
@@ -1,0 +1,31 @@
+# Scoring API
+
+## Ownership
+- **Team:** Detection Services
+- **Primary Maintainer:** Priya Raman (<praman@phishsentry.internal>)
+
+## Tech Stack
+- Python 3.11
+- FastAPI + Uvicorn
+- PostgreSQL + Redis integrations
+
+## Local Development
+```bash
+uv sync
+uv run fastapi dev app/main.py
+```
+
+## Build & Packaging
+```bash
+uv run poe lint
+uv run poe test
+uv run poe build-docker
+```
+
+## Deployment Targets
+- Kubernetes: `scoring-api` namespace in the `prod-phish` cluster
+- Staging environment: `scoring-api-stg` helm release
+
+## Contribution Notes
+- API contracts documented via OpenAPI specs under `docs/openapi`
+- Coordinate schema changes with the Model Engine team to ensure feature parity


### PR DESCRIPTION
## Summary
- scaffold packages and apps directories for browser extension, scoring API, model engine, and ops dashboard
- add component-level READMEs with ownership, build, and deployment information
- document system architecture interactions and expand gitignore for tech-specific artifacts

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e4a660fc6883279ea6b02318dee8fd