### PR TITLE
Add model engine with hybrid scoring and tests

### DIFF
--- a/packages/model-engine/README.md
+++ b/packages/model-engine/README.md
@@ -1,0 +1,54 @@
+# Model Engine
+
+This package provides phishing URL scoring that blends machine learning with transparent heuristics and list-based overrides. It can be used directly or embedded inside larger services.
+
+## Evaluating URLs
+
+```python
+from model_engine import evaluate_url
+
+result = evaluate_url("http://login-secure-update.example.com")
+print(result.score, result.label)
+print(result.factors)
+```
+
+The returned `ModelResult` exposes the blended score, threshold, contributing factors, and which model (if any) was used.
+
+## Configuration
+
+Configuration is stored in JSON (see [`default_config.json`](src/model_engine/default_config.json)). The keys include:
+
+- `model.path`: relative path to a lightweight model artifact (`artifacts/lightweight_model.json`). Set to `null` to disable ML and force heuristics.
+- `model.weight`: blending weight between the ML prediction and heuristic score.
+- `thresholds.phishing`: score at which a URL is considered malicious.
+- `blocklist` / `allowlist`: inline `items` arrays or a `path` pointing at newline-delimited files. Blocked URLs always return score `1.0`; allowed URLs return `0.0`.
+- `heuristics`: tunable thresholds and weights controlling the deterministic fallback scorer.
+
+To use a custom configuration file set the `MODEL_ENGINE_CONFIG` environment variable to its path or call `EngineConfig.load(path)` and pass the result to `evaluate_url`.
+
+## Refreshing the ML Model
+
+1. Collect labelled URLs and extract features with `model_engine.features.extract_features`.
+2. Train a logistic-regression style model (any framework) and record the learned bias plus feature weights.
+3. Export the model as JSON using the same field names as the training features, e.g.
+   ```json
+   {
+     "name": "lightweight-phish-model",
+     "bias": -0.9,
+     "weights": {"length_norm": 1.1, "keyword_flag": 1.7}
+   }
+   ```
+4. Place the artifact inside `src/model_engine/artifacts/` (or update `model.path` to the new location).
+5. Bump the configuration weight or threshold if calibration changes.
+
+Reload the engine by either restarting the service or calling `model_engine.set_config(new_config)`.
+
+## Updating Heuristics
+
+- Adjust the values inside the `heuristics` section of the configuration to change thresholds or weights.
+- Add or remove suspicious TLDs and keywords in [`features.py`](src/model_engine/features.py) to match the current landscape.
+- Tests in `tests/test_evaluator.py` cover the ML path, heuristic fallback, and list overrides—extend them when adding new rules.
+
+## Blocklists and Allowlists
+
+Maintain newline-delimited files referenced by the configuration `path` fields, or edit the `items` arrays directly. Overrides take precedence over any model score.

--- a/packages/model-engine/pyproject.toml
+++ b/packages/model-engine/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "model-engine"
+version = "0.1.0"
+description = "Hybrid phishing URL scoring engine"
+authors = [{ name = "PhishSentry" }]
+requires-python = ">=3.10"
+readme = "README.md"

--- a/packages/model-engine/src/model_engine/__init__.py
+++ b/packages/model-engine/src/model_engine/__init__.py
@@ -1,0 +1,14 @@
+"""Model engine package for phishing URL evaluation."""
+
+from .config import EngineConfig, HeuristicSettings, get_config, set_config
+from .evaluator import evaluate_url
+from .types import ModelResult
+
+__all__ = [
+    "EngineConfig",
+    "HeuristicSettings",
+    "ModelResult",
+    "evaluate_url",
+    "get_config",
+    "set_config",
+]

--- a/packages/model-engine/src/model_engine/artifacts/lightweight_model.json
+++ b/packages/model-engine/src/model_engine/artifacts/lightweight_model.json
@@ -1,0 +1,13 @@
+{
+  "name": "lightweight-phish-model",
+  "bias": -1.0,
+  "weights": {
+    "length_norm": 1.2,
+    "digit_ratio": 2.5,
+    "keyword_flag": 1.8,
+    "has_ip": 2.2,
+    "subdomain_ratio": 1.1,
+    "https_flag": -0.7,
+    "suspicious_tld": 1.5
+  }
+}

--- a/packages/model-engine/src/model_engine/config.py
+++ b/packages/model-engine/src/model_engine/config.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Sequence, Set
+
+
+_DEFAULT_CONFIG_NAME = "default_config.json"
+
+
+@dataclass
+class HeuristicSettings:
+    digit_threshold: int = 6
+    digit_weight: float = 0.15
+    length_threshold: int = 40
+    length_weight: float = 0.2
+    subdomain_threshold: int = 3
+    subdomain_weight: float = 0.15
+    suspicious_tlds: Sequence[str] = field(default_factory=lambda: ["zip", "xyz", "top", "click"])
+    suspicious_tld_weight: float = 0.15
+    keyword_weight: float = 0.2
+    https_bonus: float = 0.1
+    base_score: float = 0.05
+
+
+@dataclass
+class EngineConfig:
+    model_path: Optional[Path]
+    model_weight: float
+    phishing_threshold: float
+    blocklist: Set[str]
+    allowlist: Set[str]
+    heuristics: HeuristicSettings
+
+    @classmethod
+    def load(cls, path: Optional[Path] = None) -> "EngineConfig":
+        base_path = None
+        if path is None:
+            env_path = os.getenv("MODEL_ENGINE_CONFIG")
+            if env_path:
+                path = Path(env_path)
+            else:
+                path = Path(__file__).with_name(_DEFAULT_CONFIG_NAME)
+        else:
+            path = Path(path)
+
+        base_path = path.parent
+        with path.open("r", encoding="utf-8") as handle:
+            raw: Dict[str, object] = json.load(handle)
+        return cls.from_dict(raw, base_path=base_path)
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object], base_path: Optional[Path] = None) -> "EngineConfig":
+        model_section = payload.get("model", {})
+        model_path = model_section.get("path") if isinstance(model_section, dict) else None
+        resolved_model_path = Path(model_path) if model_path else None
+        if resolved_model_path and base_path and not resolved_model_path.is_absolute():
+            resolved_model_path = (base_path / resolved_model_path).resolve()
+
+        model_weight = float(model_section.get("weight", 0.7)) if isinstance(model_section, dict) else 0.7
+
+        thresholds = payload.get("thresholds", {})
+        phishing_threshold = float(thresholds.get("phishing", 0.6)) if isinstance(thresholds, dict) else 0.6
+
+        heuristics_payload = payload.get("heuristics", {})
+        heuristics = HeuristicSettings(
+            digit_threshold=int(heuristics_payload.get("digit_threshold", 6))
+            if isinstance(heuristics_payload, dict)
+            else 6,
+            digit_weight=float(heuristics_payload.get("digit_weight", 0.15))
+            if isinstance(heuristics_payload, dict)
+            else 0.15,
+            length_threshold=int(heuristics_payload.get("length_threshold", 40))
+            if isinstance(heuristics_payload, dict)
+            else 40,
+            length_weight=float(heuristics_payload.get("length_weight", 0.2))
+            if isinstance(heuristics_payload, dict)
+            else 0.2,
+            subdomain_threshold=int(heuristics_payload.get("subdomain_threshold", 3))
+            if isinstance(heuristics_payload, dict)
+            else 3,
+            subdomain_weight=float(heuristics_payload.get("subdomain_weight", 0.15))
+            if isinstance(heuristics_payload, dict)
+            else 0.15,
+            suspicious_tlds=tuple(heuristics_payload.get("suspicious_tlds", ["zip", "xyz", "top", "click"]))
+            if isinstance(heuristics_payload, dict)
+            else ("zip", "xyz", "top", "click"),
+            suspicious_tld_weight=float(heuristics_payload.get("suspicious_tld_weight", 0.15))
+            if isinstance(heuristics_payload, dict)
+            else 0.15,
+            keyword_weight=float(heuristics_payload.get("keyword_weight", 0.2))
+            if isinstance(heuristics_payload, dict)
+            else 0.2,
+            https_bonus=float(heuristics_payload.get("https_bonus", 0.1))
+            if isinstance(heuristics_payload, dict)
+            else 0.1,
+            base_score=float(heuristics_payload.get("base_score", 0.05))
+            if isinstance(heuristics_payload, dict)
+            else 0.05,
+        )
+
+        blocklist = _load_list(payload.get("blocklist"), base_path=base_path)
+        allowlist = _load_list(payload.get("allowlist"), base_path=base_path)
+
+        return cls(
+            model_path=resolved_model_path,
+            model_weight=model_weight,
+            phishing_threshold=phishing_threshold,
+            blocklist=blocklist,
+            allowlist=allowlist,
+            heuristics=heuristics,
+        )
+
+
+def _load_list(raw: object, base_path: Optional[Path]) -> Set[str]:
+    if raw is None:
+        return set()
+    if isinstance(raw, (list, tuple, set)):
+        return {str(item).strip() for item in raw if str(item).strip()}
+    if isinstance(raw, dict):
+        values: Set[str] = set()
+        items: Iterable[str] = raw.get("items", []) if isinstance(raw.get("items"), Iterable) else []
+        for item in items:
+            text = str(item).strip()
+            if text:
+                values.add(text)
+        list_path = raw.get("path")
+        if list_path:
+            file_path = Path(list_path)
+            if base_path and not file_path.is_absolute():
+                file_path = (base_path / file_path).resolve()
+            if file_path.exists():
+                with file_path.open("r", encoding="utf-8") as handle:
+                    for line in handle:
+                        text = line.strip()
+                        if text and not text.startswith("#"):
+                            values.add(text)
+        return values
+    raise TypeError(f"Unsupported list specification: {raw!r}")
+
+
+_config: Optional[EngineConfig] = None
+
+
+def get_config() -> EngineConfig:
+    global _config
+    if _config is None:
+        _config = EngineConfig.load()
+    return _config
+
+
+def set_config(config: EngineConfig) -> None:
+    global _config
+    _config = config

--- a/packages/model-engine/src/model_engine/default_config.json
+++ b/packages/model-engine/src/model_engine/default_config.json
@@ -1,0 +1,33 @@
+{
+  "model": {
+    "path": "artifacts/lightweight_model.json",
+    "weight": 0.7
+  },
+  "thresholds": {
+    "phishing": 0.6
+  },
+  "blocklist": {
+    "items": [
+      "http://malware.test",
+      "http://phish.example"
+    ]
+  },
+  "allowlist": {
+    "items": [
+      "https://security.example"
+    ]
+  },
+  "heuristics": {
+    "digit_threshold": 6,
+    "digit_weight": 0.15,
+    "length_threshold": 40,
+    "length_weight": 0.2,
+    "subdomain_threshold": 3,
+    "subdomain_weight": 0.15,
+    "suspicious_tlds": ["zip", "xyz", "top", "click"],
+    "suspicious_tld_weight": 0.15,
+    "keyword_weight": 0.25,
+    "https_bonus": 0.1,
+    "base_score": 0.05
+  }
+}

--- a/packages/model-engine/src/model_engine/evaluator.py
+++ b/packages/model-engine/src/model_engine/evaluator.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .config import EngineConfig, get_config
+from .features import extract_features
+from .heuristics import score_with_heuristics
+from .model import ModelNotAvailable, UrlModel
+from .types import ModelResult
+
+
+@dataclass
+class _ModelCache:
+    model: Optional[UrlModel] = None
+    path: Optional[str] = None
+
+
+_model_cache = _ModelCache()
+
+
+def evaluate_url(url: str, config: Optional[EngineConfig] = None) -> ModelResult:
+    """Score *url* and explain the contributing factors."""
+
+    cfg = config or get_config()
+
+    if url in cfg.allowlist:
+        return ModelResult(
+            url=url,
+            score=0.0,
+            label="allow",
+            threshold=cfg.phishing_threshold,
+            factors={"reason": "allowlist"},
+            overrides=["allowlist"],
+            model_used=None,
+        )
+
+    if url in cfg.blocklist:
+        return ModelResult(
+            url=url,
+            score=1.0,
+            label="block",
+            threshold=cfg.phishing_threshold,
+            factors={"reason": "blocklist"},
+            overrides=["blocklist"],
+            model_used=None,
+        )
+
+    features = extract_features(url)
+    heuristics_score, heuristic_contrib = score_with_heuristics(features, cfg.heuristics)
+
+    model_score = None
+    model_used = None
+    if cfg.model_path:
+        model = _get_or_load_model(cfg)
+        if model:
+            model_score = model.predict_probability(features)
+            model_used = model.name
+
+    factors = {
+        "heuristics": {
+            "score": heuristics_score,
+            "contributions": heuristic_contrib,
+        }
+    }
+
+    final_score: float
+    if model_score is not None:
+        final_score = cfg.model_weight * model_score + (1 - cfg.model_weight) * heuristics_score
+        factors["model_score"] = model_score
+    else:
+        final_score = heuristics_score
+        model_used = None
+
+    final_score = max(0.0, min(final_score, 1.0))
+
+    label = "malicious" if final_score >= cfg.phishing_threshold else "benign"
+
+    return ModelResult(
+        url=url,
+        score=final_score,
+        label=label,
+        threshold=cfg.phishing_threshold,
+        factors=factors,
+        overrides=[],
+        model_used=model_used,
+    )
+
+
+def _get_or_load_model(config: EngineConfig) -> Optional[UrlModel]:
+    if not config.model_path:
+        return None
+    path_str = str(config.model_path)
+    if _model_cache.model and _model_cache.path == path_str:
+        return _model_cache.model
+
+    try:
+        model = UrlModel.load(config.model_path)
+    except ModelNotAvailable:
+        _model_cache.model = None
+        _model_cache.path = None
+        return None
+
+    _model_cache.model = model
+    _model_cache.path = path_str
+    return model

--- a/packages/model-engine/src/model_engine/features.py
+++ b/packages/model-engine/src/model_engine/features.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict
+from urllib.parse import urlparse
+
+_SUSPICIOUS_KEYWORDS = (
+    "login",
+    "secure",
+    "update",
+    "verify",
+    "account",
+    "bank",
+    "invoice",
+    "alert",
+)
+
+_IP_PATTERN = re.compile(
+    r"^(?:(?:25[0-5]|2[0-4]\d|[0-1]?\d?\d)(?:\.(?!$)|$)){4}$"
+)
+
+
+@dataclass
+class FeatureVector:
+    values: Dict[str, float]
+
+
+def extract_features(url: str) -> FeatureVector:
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    length_norm = min(len(url) / 100, 1.0)
+    digit_ratio = _count_digits(url) / max(len(url), 1)
+    keyword_flag = 1.0 if any(word in url.lower() for word in _SUSPICIOUS_KEYWORDS) else 0.0
+    has_ip = 1.0 if _IP_PATTERN.match(host) else 0.0
+    subdomain_ratio = min(max(host.count(".") - 1, 0) / 4, 1.0)
+    https_flag = 1.0 if parsed.scheme == "https" else 0.0
+    suspicious_tld = 1.0 if _tld_is_suspicious(host) else 0.0
+
+    values = {
+        "length_norm": length_norm,
+        "digit_ratio": digit_ratio,
+        "keyword_flag": keyword_flag,
+        "has_ip": has_ip,
+        "subdomain_ratio": subdomain_ratio,
+        "https_flag": https_flag,
+        "suspicious_tld": suspicious_tld,
+    }
+    return FeatureVector(values=values)
+
+
+def _count_digits(text: str) -> int:
+    return sum(1 for char in text if char.isdigit())
+
+
+def _tld_is_suspicious(host: str) -> bool:
+    if "." not in host:
+        return False
+    tld = host.split(".")[-1].lower()
+    return tld in {"zip", "xyz", "top", "click", "link"}

--- a/packages/model-engine/src/model_engine/heuristics.py
+++ b/packages/model-engine/src/model_engine/heuristics.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+from .config import HeuristicSettings
+from .features import FeatureVector
+
+
+def score_with_heuristics(features: FeatureVector, settings: HeuristicSettings) -> Tuple[float, Dict[str, float]]:
+    """Compute a deterministic heuristic score based on the extracted features."""
+
+    contributions: Dict[str, float] = {}
+    score = settings.base_score
+    if settings.base_score:
+        contributions["base"] = settings.base_score
+
+    values = features.values
+
+    if values.get("keyword_flag", 0.0) > 0:
+        contributions["keyword_match"] = settings.keyword_weight
+        score += settings.keyword_weight
+
+    if values.get("digit_ratio", 0.0) * 100 >= settings.digit_threshold:
+        contributions["many_digits"] = settings.digit_weight
+        score += settings.digit_weight
+
+    length_estimate = values.get("length_norm", 0.0) * 100
+    if length_estimate >= settings.length_threshold:
+        contributions["long_url"] = settings.length_weight
+        score += settings.length_weight
+
+    subdomain_ratio = values.get("subdomain_ratio", 0.0)
+    if subdomain_ratio * 4 >= settings.subdomain_threshold:
+        contributions["deep_subdomains"] = settings.subdomain_weight
+        score += settings.subdomain_weight
+
+    if values.get("suspicious_tld", 0.0) > 0:
+        contributions["suspicious_tld"] = settings.suspicious_tld_weight
+        score += settings.suspicious_tld_weight
+
+    if values.get("https_flag", 0.0) > 0:
+        # HTTPS slightly reduces the risk score but never below zero.
+        bonus = min(settings.https_bonus, score)
+        if bonus:
+            contributions["https"] = -bonus
+            score -= bonus
+
+    score = max(0.0, min(score, 1.0))
+    return score, contributions

--- a/packages/model-engine/src/model_engine/model.py
+++ b/packages/model-engine/src/model_engine/model.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+from .features import FeatureVector
+
+
+class ModelNotAvailable(RuntimeError):
+    """Raised when the ML model cannot be loaded."""
+
+
+@dataclass
+class UrlModel:
+    name: str
+    weights: Dict[str, float]
+    bias: float
+
+    @classmethod
+    def load(cls, path: Path) -> "UrlModel":
+        if not path or not path.exists():
+            raise ModelNotAvailable(f"Model artifact not found at {path}")
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        return cls(
+            name=payload.get("name", "lightweight-phish-model"),
+            weights=payload.get("weights", {}),
+            bias=float(payload.get("bias", 0.0)),
+        )
+
+    def predict_probability(self, features: FeatureVector) -> float:
+        score = self.bias
+        for name, value in features.values.items():
+            weight = self.weights.get(name)
+            if weight is None:
+                continue
+            score += weight * value
+        return _sigmoid(score)
+
+
+def _sigmoid(value: float) -> float:
+    return 1.0 / (1.0 + math.exp(-value))

--- a/packages/model-engine/src/model_engine/types.py
+++ b/packages/model-engine/src/model_engine/types.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class ModelResult:
+    """Represents the outcome of scoring a URL."""
+
+    url: str
+    score: float
+    label: str
+    threshold: float
+    factors: Dict[str, Any] = field(default_factory=dict)
+    overrides: List[str] = field(default_factory=list)
+    model_used: Optional[str] = None
+
+    def is_malicious(self) -> bool:
+        """True when the URL was classified as malicious."""
+
+        return self.score >= self.threshold and "allowlist" not in self.overrides

--- a/packages/model-engine/tests/test_evaluator.py
+++ b/packages/model-engine/tests/test_evaluator.py
@@ -1,0 +1,85 @@
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from model_engine.config import EngineConfig
+from model_engine.evaluator import evaluate_url
+from model_engine.heuristics import score_with_heuristics
+from model_engine.features import extract_features
+
+
+def load_default_config() -> EngineConfig:
+    config_path = SRC_PATH / "model_engine" / "default_config.json"
+    return EngineConfig.load(config_path)
+
+
+def test_ml_evaluation_uses_model():
+    config = load_default_config()
+    url = "http://login-secure-update.example.com/account"
+    result = evaluate_url(url, config=config)
+
+    assert result.model_used == "lightweight-phish-model"
+    assert "model_score" in result.factors
+    assert result.factors["model_score"] > result.factors["heuristics"]["score"]
+    assert result.is_malicious()
+
+
+def test_heuristic_fallback_when_model_missing():
+    config_payload = {
+        "model": {"path": None, "weight": 0.5},
+        "thresholds": {"phishing": 0.5},
+        "blocklist": [],
+        "allowlist": [],
+        "heuristics": {
+            "digit_threshold": 5,
+            "digit_weight": 0.2,
+            "length_threshold": 30,
+            "length_weight": 0.2,
+            "subdomain_threshold": 2,
+            "subdomain_weight": 0.2,
+            "suspicious_tlds": ["zip"],
+            "suspicious_tld_weight": 0.2,
+            "keyword_weight": 0.2,
+            "https_bonus": 0.05,
+            "base_score": 0.1,
+        },
+    }
+    config = EngineConfig.from_dict(config_payload, base_path=SRC_PATH)
+
+    url = "https://safe.example.com/profile"
+    result = evaluate_url(url, config=config)
+
+    assert result.model_used is None
+    heuristics_score, _ = score_with_heuristics(extract_features(url), config.heuristics)
+    assert math.isclose(result.score, heuristics_score)
+    assert result.label == "benign"
+
+
+def test_block_and_allow_list_override():
+    config_payload = {
+        "model": {"path": None, "weight": 0.5},
+        "thresholds": {"phishing": 0.5},
+        "blocklist": {"items": ["http://evil.example"]},
+        "allowlist": {"items": ["https://trusted.example"]},
+        "heuristics": {},
+    }
+    config = EngineConfig.from_dict(config_payload, base_path=SRC_PATH)
+
+    allow_result = evaluate_url("https://trusted.example", config=config)
+    assert allow_result.score == pytest.approx(0.0)
+    assert allow_result.label == "allow"
+    assert "allowlist" in allow_result.overrides
+    assert not allow_result.is_malicious()
+
+    block_result = evaluate_url("http://evil.example", config=config)
+    assert block_result.score == pytest.approx(1.0)
+    assert block_result.label == "block"
+    assert "blocklist" in block_result.overrides
+    assert block_result.is_malicious()


### PR DESCRIPTION
## Summary
- create a model-engine package that extracts URL features, blends ML inference with heuristics, and exposes an evaluate_url API
- provide configuration, lightweight model artifacts, and documentation for maintaining blocklists and heuristics
- add tests to cover ML scoring, heuristic fallback, and list overrides

## Testing
- pytest packages/model-engine/tests

------
https://chatgpt.com/codex/tasks/task_e_68e4a681ea048327b3d3a09864bd49de