### PR TITLE
Add MV3 browser extension scaffold for link risk scanning

### DIFF
--- a/packages/browser-extension/.eslintrc.cjs
+++ b/packages/browser-extension/.eslintrc.cjs
@@ -1,0 +1,31 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: null,
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  plugins: ['@typescript-eslint', 'import'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  rules: {
+    'import/order': [
+      'warn',
+      {
+        groups: [['builtin', 'external'], 'internal', ['parent', 'sibling', 'index']],
+        'newlines-between': 'always',
+      },
+    ],
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-misused-promises': [
+      'error',
+      {
+        checksVoidReturn: false,
+      }
+    ]
+  },
+};

--- a/packages/browser-extension/README.md
+++ b/packages/browser-extension/README.md
@@ -1,0 +1,52 @@
+# PhishSentry Browser Extension
+
+A Manifest V3 compliant browser extension that scans links across Gmail, popular social platforms, and general websites using the PhishSentry API.
+
+## Features
+
+- Background service worker requests phishing-risk insights from the PhishSentry API with caching and offline handling.
+- Content scripts highlight links, append badges, and expose a floating details panel with actionable guidance.
+- Environment-aware configuration for API endpoint, token, and timeout.
+- Build targets for Chrome and Firefox bundles, plus linting and type checking support.
+
+## Getting Started
+
+```bash
+cd packages/browser-extension
+npm install
+```
+
+Create environment files as needed (e.g. `.env`, `.env.chrome`, `.env.firefox`) with:
+
+```
+VITE_API_ENDPOINT=https://api.example.com/scan
+VITE_API_TOKEN=your-api-token
+VITE_API_TIMEOUT_MS=4000
+```
+
+> The repository deliberately avoids hard-coding secrets. Configure the real endpoint and token locally.
+
+## Scripts
+
+- `npm run dev` – Watch mode for Chrome with Vite.
+- `npm run build:chrome` – Build the Chrome MV3 bundle to `dist/chrome`.
+- `npm run build:firefox` – Build the Firefox MV3 bundle to `dist/firefox`.
+- `npm run lint` – ESLint across the TypeScript sources.
+- `npm run typecheck` – TypeScript compiler in `--noEmit` mode.
+- `npm run qa` – Print manual QA steps for loading the extension unpacked.
+
+## Manual QA Summary
+
+1. Build the target bundle.
+2. Load the unpacked directory in your browser (`chrome://extensions` or `about:debugging#` for Firefox).
+3. Visit Gmail, Facebook/Twitter/LinkedIn/Instagram, and a generic website.
+4. Confirm risk badges appear near links and the details panel opens with context from the API response.
+5. Toggle offline mode and verify the extension surfaces cached or offline messaging.
+6. Check DevTools for errors.
+
+## Development Notes
+
+- The background worker caches API responses for five minutes to reduce repeated requests.
+- Content scripts automatically observe DOM mutations to cover SPA experiences.
+- Styling is encapsulated via prefixed classes to minimise CSS bleed.
+- Update `manifest.chrome.json` and `manifest.firefox.json` if you adjust host permissions or content script matches.

--- a/packages/browser-extension/manifest.chrome.json
+++ b/packages/browser-extension/manifest.chrome.json
@@ -1,0 +1,38 @@
+{
+  "manifest_version": 3,
+  "name": "PhishSentry",
+  "description": "Highlights risky links across Gmail, websites, and social platforms with quick access to API-backed insights.",
+  "version": "0.1.0",
+  "background": {
+    "service_worker": "background/index.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "PhishSentry"
+  },
+  "permissions": ["storage"],
+  "host_permissions": ["<all_urls>"],
+  "content_scripts": [
+    {
+      "matches": ["https://mail.google.com/*"],
+      "js": ["content/gmail.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": [
+        "https://*.facebook.com/*",
+        "https://*.twitter.com/*",
+        "https://*.linkedin.com/*",
+        "https://*.instagram.com/*"
+      ],
+      "js": ["content/social.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://*/*", "http://*/*"],
+      "exclude_matches": ["https://mail.google.com/*"],
+      "js": ["content/web.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/packages/browser-extension/manifest.firefox.json
+++ b/packages/browser-extension/manifest.firefox.json
@@ -1,0 +1,43 @@
+{
+  "manifest_version": 3,
+  "name": "PhishSentry",
+  "description": "Highlights risky links across Gmail, websites, and social platforms with quick access to API-backed insights.",
+  "version": "0.1.0",
+  "background": {
+    "service_worker": "background/index.js"
+  },
+  "action": {
+    "default_title": "PhishSentry"
+  },
+  "permissions": ["storage"],
+  "host_permissions": ["<all_urls>"],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "phishsentry@example.com",
+      "strict_min_version": "109.0"
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://mail.google.com/*"],
+      "js": ["content/gmail.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": [
+        "https://*.facebook.com/*",
+        "https://*.twitter.com/*",
+        "https://*.linkedin.com/*",
+        "https://*.instagram.com/*"
+      ],
+      "js": ["content/social.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://*/*", "http://*/*"],
+      "exclude_matches": ["https://mail.google.com/*"],
+      "js": ["content/web.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/packages/browser-extension/package.json
+++ b/packages/browser-extension/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "phishsentry-browser-extension",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "TARGET=chrome vite",
+    "build": "npm run build:chrome",
+    "build:chrome": "cross-env TARGET=chrome vite build",
+    "build:firefox": "cross-env TARGET=firefox vite build",
+    "lint": "eslint --ext .ts src",
+    "typecheck": "tsc --noEmit",
+    "qa": "node scripts/manual-qa.js"
+  },
+  "devDependencies": {
+    "@types/chrome": "^0.0.246",
+    "@typescript-eslint/eslint-plugin": "^7.17.0",
+    "@typescript-eslint/parser": "^7.17.0",
+    "cross-env": "^7.0.3",
+    "eslint": "^8.57.0",
+    "eslint-plugin-import": "^2.29.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.2.0",
+    "vite-plugin-static-copy": "^0.17.1"
+  }
+}

--- a/packages/browser-extension/scripts/manual-qa.js
+++ b/packages/browser-extension/scripts/manual-qa.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const distChrome = path.join(__dirname, '..', 'dist', 'chrome');
+const distFirefox = path.join(__dirname, '..', 'dist', 'firefox');
+
+const steps = `Manual QA Checklist\n====================\n\nChrome\n------\n1. Run \`npm install\` within \`packages/browser-extension\`.\n2. Build the Chrome bundle with \`npm run build:chrome\`.\n3. Open Chrome and navigate to chrome://extensions.\n4. Enable Developer Mode and choose "Load unpacked".\n5. Select the built directory: ${distChrome}.\n6. Open Gmail, a social site, and a generic website to confirm badges appear next to links.\n7. Click a badge to verify the PhishSentry panel opens with API results and offline messaging.\n\nFirefox\n-------\n1. Run \`npm install\` if you have not already.\n2. Build the Firefox bundle with \`npm run build:firefox\`.\n3. Open Firefox and go to about:debugging#/runtime/this-firefox.\n4. Use "Load Temporary Add-on" and select the \`manifest.json\` within ${distFirefox}.\n5. Repeat the same navigation checks as Chrome.\n\nValidation\n---------\n- Toggle network offline to confirm the extension gracefully falls back to cached or offline messaging.\n- Confirm the details panel can be dismissed and reopened.\n- Review the browser console for any runtime errors.`;
+
+console.log(steps);

--- a/packages/browser-extension/src/background/index.ts
+++ b/packages/browser-extension/src/background/index.ts
@@ -1,0 +1,160 @@
+import { ApiResponse, getRuntimeConfig, isOffline, RiskAssessment } from '../config';
+
+interface ScanCacheEntry {
+  timestamp: number;
+  response: ApiResponse;
+}
+
+const cache = new Map<string, ScanCacheEntry>();
+const CACHE_TTL = 5 * 60 * 1000; // five minutes
+
+const buildHeaders = (token?: string): HeadersInit => {
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+};
+
+const buildTimeout = <T>(promise: Promise<T>, timeoutMs: number): Promise<T> => {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Request timeout'));
+    }, timeoutMs);
+
+    promise
+      .then((value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      })
+      .catch((error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+  });
+};
+
+const fromCache = (url: string): ApiResponse | undefined => {
+  const entry = cache.get(url);
+  if (!entry) {
+    return undefined;
+  }
+
+  if (Date.now() - entry.timestamp > CACHE_TTL) {
+    cache.delete(url);
+    return undefined;
+  }
+
+  return entry.response;
+};
+
+const saveToCache = (url: string, response: ApiResponse): void => {
+  cache.set(url, {
+    timestamp: Date.now(),
+    response,
+  });
+};
+
+const mapAssessment = (url: string, payload: unknown): RiskAssessment | undefined => {
+  if (!payload || typeof payload !== 'object') {
+    return undefined;
+  }
+
+  const record = payload as Record<string, unknown>;
+  const riskLevel = typeof record.riskLevel === 'string' ? (record.riskLevel as RiskAssessment['riskLevel']) : 'unknown';
+
+  return {
+    url,
+    riskLevel,
+    score: typeof record.score === 'number' ? record.score : undefined,
+    reason: typeof record.reason === 'string' ? record.reason : undefined,
+    guidance: typeof record.guidance === 'string' ? record.guidance : undefined,
+  };
+};
+
+const scanUrl = async (url: string): Promise<ApiResponse> => {
+  const cached = fromCache(url);
+  if (cached) {
+    return cached;
+  }
+
+  if (!url) {
+    return { status: 'error', message: 'Invalid URL' };
+  }
+
+  if (isOffline()) {
+    const offlineResponse: ApiResponse = {
+      status: 'offline',
+      message: 'No network connection. Using cached data if available.',
+      assessment: cached?.assessment ?? { url, riskLevel: 'unknown' },
+    };
+    saveToCache(url, offlineResponse);
+    return offlineResponse;
+  }
+
+  const { apiEndpoint, apiToken, requestTimeout } = getRuntimeConfig();
+
+  try {
+    const response = await buildTimeout(
+      fetch(apiEndpoint, {
+        method: 'POST',
+        headers: buildHeaders(apiToken),
+        body: JSON.stringify({ url }),
+      }),
+      requestTimeout
+    );
+
+    if (!response.ok) {
+      const errorResponse: ApiResponse = {
+        status: 'error',
+        message: `API responded with status ${response.status}`,
+      };
+      saveToCache(url, errorResponse);
+      return errorResponse;
+    }
+
+    const payload = await response.json();
+    const assessment = mapAssessment(url, (payload as Record<string, unknown>).assessment ?? payload);
+
+    const successResponse: ApiResponse = {
+      status: 'ok',
+      assessment: assessment ?? { url, riskLevel: 'unknown' },
+    };
+    saveToCache(url, successResponse);
+    return successResponse;
+  } catch (error) {
+    const errorResponse: ApiResponse = {
+      status: isOffline() ? 'offline' : 'error',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    };
+    saveToCache(url, errorResponse);
+    return errorResponse;
+  }
+};
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.type !== 'SCAN_URL') {
+    return;
+  }
+
+  const { url } = message;
+  scanUrl(url)
+    .then(sendResponse)
+    .catch((error) => {
+      const fallback: ApiResponse = {
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Unexpected failure',
+      };
+      sendResponse(fallback);
+    });
+
+  return true;
+});
+
+chrome.runtime.onInstalled.addListener(() => {
+  console.info('PhishSentry extension installed for target:', __TARGET__);
+});

--- a/packages/browser-extension/src/config.ts
+++ b/packages/browser-extension/src/config.ts
@@ -1,0 +1,44 @@
+export type ApiStatus = 'ok' | 'error' | 'offline';
+
+export interface RiskAssessment {
+  url: string;
+  riskLevel: 'low' | 'medium' | 'high' | 'unknown';
+  score?: number;
+  reason?: string;
+  guidance?: string;
+}
+
+export interface ApiResponse {
+  status: ApiStatus;
+  assessment?: RiskAssessment;
+  message?: string;
+}
+
+export interface RuntimeConfig {
+  apiEndpoint: string;
+  apiToken?: string;
+  requestTimeout: number;
+}
+
+const FALLBACK_ENDPOINT = 'https://api.phishsentry.invalid/scan';
+const FALLBACK_TIMEOUT = 4000;
+
+export const getRuntimeConfig = (): RuntimeConfig => {
+  const { VITE_API_ENDPOINT, VITE_API_TOKEN, VITE_API_TIMEOUT_MS } = import.meta.env;
+
+  const requestTimeout = Number.parseInt(VITE_API_TIMEOUT_MS ?? '', 10);
+
+  return {
+    apiEndpoint: VITE_API_ENDPOINT?.trim() || FALLBACK_ENDPOINT,
+    apiToken: VITE_API_TOKEN?.trim(),
+    requestTimeout: Number.isFinite(requestTimeout) ? requestTimeout : FALLBACK_TIMEOUT,
+  };
+};
+
+export const isOffline = (): boolean => {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  return navigator.onLine === false;
+};

--- a/packages/browser-extension/src/content/gmail.ts
+++ b/packages/browser-extension/src/content/gmail.ts
@@ -1,0 +1,9 @@
+import { startLinkScanner } from './linkHighlighter';
+
+document.addEventListener('DOMContentLoaded', () => {
+  startLinkScanner();
+});
+
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+  startLinkScanner();
+}

--- a/packages/browser-extension/src/content/linkHighlighter.ts
+++ b/packages/browser-extension/src/content/linkHighlighter.ts
@@ -1,0 +1,152 @@
+import type { ApiResponse } from '../config';
+import { createPanelController } from './panel';
+import './styles.css';
+
+const panel = createPanelController();
+const processedLinks = new WeakSet<HTMLAnchorElement>();
+const inflightRequests = new Map<string, Promise<ApiResponse>>();
+
+const sendScanRequest = (url: string): Promise<ApiResponse> => {
+  if (!url) {
+    return Promise.resolve({ status: 'error', message: 'Invalid URL provided.' });
+  }
+
+  const existing = inflightRequests.get(url);
+  if (existing) {
+    return existing;
+  }
+
+  const request = new Promise<ApiResponse>((resolve) => {
+    chrome.runtime.sendMessage({ type: 'SCAN_URL', url }, (response: ApiResponse) => {
+      if (chrome.runtime.lastError) {
+        resolve({ status: 'error', message: chrome.runtime.lastError.message });
+        inflightRequests.delete(url);
+        return;
+      }
+
+      if (!response) {
+        resolve({ status: 'error', message: 'Empty response from background worker.' });
+        inflightRequests.delete(url);
+        return;
+      }
+
+      resolve(response);
+      inflightRequests.delete(url);
+    });
+  });
+
+  inflightRequests.set(url, request);
+  return request;
+};
+
+const getBadgeLabel = (response: ApiResponse): string => {
+  const risk = response.assessment?.riskLevel ?? 'unknown';
+  switch (risk) {
+    case 'high':
+      return 'High risk';
+    case 'medium':
+      return 'Medium risk';
+    case 'low':
+      return 'Low risk';
+    default:
+      return response.status === 'offline' ? 'Offline' : 'Unknown';
+  }
+};
+
+const decorateLink = (link: HTMLAnchorElement, response: ApiResponse) => {
+  link.classList.add('ps-link-flagged');
+  const risk = response.assessment?.riskLevel ?? 'unknown';
+
+  let badge = link.nextElementSibling;
+  if (!badge || !(badge instanceof HTMLElement) || !badge.classList.contains('ps-risk-badge')) {
+    badge = document.createElement('span');
+    badge.className = 'ps-risk-badge';
+    badge.tabIndex = 0;
+    badge.setAttribute('role', 'button');
+    badge.setAttribute('aria-label', 'View phishing risk details');
+    link.insertAdjacentElement('afterend', badge);
+  }
+
+  badge.dataset.risk = risk;
+  badge.textContent = getBadgeLabel(response);
+
+  const showPanel = () => {
+    panel.show({
+      ...response,
+      assessment: {
+        url: response.assessment?.url ?? link.href,
+        riskLevel: risk,
+        score: response.assessment?.score,
+        reason: response.assessment?.reason,
+        guidance: response.assessment?.guidance,
+      },
+    });
+  };
+
+  badge.addEventListener('click', showPanel);
+  badge.addEventListener('keypress', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      showPanel();
+    }
+  });
+
+  link.addEventListener('click', () => {
+    showPanel();
+  });
+};
+
+const processLink = async (link: HTMLAnchorElement) => {
+  if (processedLinks.has(link)) {
+    return;
+  }
+
+  processedLinks.add(link);
+
+  try {
+    const response = await sendScanRequest(link.href);
+    decorateLink(link, response);
+  } catch (error) {
+    console.error('Failed to process link', error);
+  }
+};
+
+const observeLinks = (root: ParentNode = document): void => {
+  const initialLinks = Array.from(root.querySelectorAll<HTMLAnchorElement>('a[href^="http"]'));
+  initialLinks.forEach((link) => {
+    if (link.href.startsWith('chrome-extension://')) {
+      return;
+    }
+    processLink(link).catch((error) => console.error(error));
+  });
+};
+
+const mutationObserver = new MutationObserver((mutations) => {
+  for (const mutation of mutations) {
+    mutation.addedNodes.forEach((node) => {
+      if (node.nodeType !== Node.ELEMENT_NODE) {
+        return;
+      }
+
+      const element = node as Element;
+      if (element instanceof HTMLAnchorElement && element.href) {
+        processLink(element).catch((error) => console.error(error));
+        return;
+      }
+
+      observeLinks(element);
+    });
+  }
+});
+
+let isRunning = false;
+
+export const startLinkScanner = (): void => {
+  if (isRunning) {
+    return;
+  }
+
+  isRunning = true;
+  observeLinks();
+  mutationObserver.observe(document.body, { childList: true, subtree: true });
+};

--- a/packages/browser-extension/src/content/panel.ts
+++ b/packages/browser-extension/src/content/panel.ts
@@ -1,0 +1,100 @@
+import type { ApiResponse, RiskAssessment } from '../config';
+import './styles.css';
+
+interface PanelController {
+  show: (response: ApiResponse) => void;
+}
+
+const formatRiskLabel = (assessment?: RiskAssessment): string => {
+  if (!assessment) {
+    return 'Unknown';
+  }
+
+  const { riskLevel, score } = assessment;
+  const label = riskLevel.charAt(0).toUpperCase() + riskLevel.slice(1);
+  if (typeof score === 'number') {
+    return `${label} (${score.toFixed(0)})`;
+  }
+  return label;
+};
+
+const ensurePanel = (): HTMLDivElement => {
+  let panel = document.querySelector<HTMLDivElement>('.ps-panel-container');
+  if (panel) {
+    return panel;
+  }
+
+  panel = document.createElement('div');
+  panel.className = 'ps-panel-container';
+  panel.dataset.open = 'false';
+
+  panel.innerHTML = `
+    <div class="ps-panel-header">
+      <h3 class="ps-panel-title">PhishSentry Link Insights</h3>
+      <button type="button" class="ps-panel-close" aria-label="Close">Close</button>
+    </div>
+    <div class="ps-panel-body ps-muted">
+      Select a flagged link to view details.
+    </div>
+  `;
+
+  document.body.append(panel);
+
+  const closeButton = panel.querySelector<HTMLButtonElement>('.ps-panel-close');
+  closeButton?.addEventListener('click', () => {
+    panel!.dataset.open = 'false';
+  });
+
+  return panel;
+};
+
+const renderBody = (container: HTMLElement, response: ApiResponse): void => {
+  const { assessment, status, message } = response;
+  const riskLevel = assessment?.riskLevel ?? 'unknown';
+  const reason = assessment?.reason ?? 'No specific reasoning provided.';
+  const guidance = assessment?.guidance ?? 'Exercise caution when interacting with this link.';
+
+  container.innerHTML = `
+    <div class="ps-panel-metadata">
+      <div><strong>Status</strong> ${status.toUpperCase()}</div>
+      <div><strong>Risk</strong> ${formatRiskLabel(assessment)}</div>
+      <div><strong>URL</strong> ${assessment?.url ?? 'Unavailable'}</div>
+    </div>
+    <div style="margin-top:16px;">
+      <strong>Reason</strong>
+      <p>${reason}</p>
+    </div>
+    <div style="margin-top:16px;">
+      <strong>Guidance</strong>
+      <p>${guidance}</p>
+    </div>
+    ${message ? `<p class="ps-muted" style="margin-top:12px;">${message}</p>` : ''}
+  `;
+
+  const header = container.parentElement?.querySelector<HTMLElement>('.ps-panel-header');
+  if (header) {
+    header.style.background =
+      riskLevel === 'high'
+        ? 'linear-gradient(120deg, #dc2626, #b91c1c)'
+        : riskLevel === 'medium'
+        ? 'linear-gradient(120deg, #f59e0b, #d97706)'
+        : riskLevel === 'low'
+        ? 'linear-gradient(120deg, #10b981, #059669)'
+        : 'linear-gradient(120deg, #2563eb, #7c3aed)';
+  }
+};
+
+export const createPanelController = (): PanelController => {
+  const panel = ensurePanel();
+  const body = panel.querySelector<HTMLElement>('.ps-panel-body');
+  if (!body) {
+    throw new Error('Panel body element missing');
+  }
+
+  const show = (response: ApiResponse) => {
+    renderBody(body, response);
+    panel.dataset.open = 'true';
+  };
+
+  return { show };
+};

--- a/packages/browser-extension/src/content/social.ts
+++ b/packages/browser-extension/src/content/social.ts
@@ -1,0 +1,3 @@
+import { startLinkScanner } from './linkHighlighter';
+
+startLinkScanner();

--- a/packages/browser-extension/src/content/styles.css
+++ b/packages/browser-extension/src/content/styles.css
@@ -1,0 +1,112 @@
+.ps-link-flagged {
+  position: relative;
+  border-bottom: 2px dotted rgba(255, 166, 0, 0.8);
+  cursor: help;
+}
+
+.ps-risk-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 6px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #1f2933;
+  background-color: #f9fafb;
+  border: 1px solid rgba(31, 41, 51, 0.2);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.15);
+}
+
+.ps-risk-badge[data-risk='high'] {
+  background-color: #fee2e2;
+  border-color: #f87171;
+  color: #7f1d1d;
+}
+
+.ps-risk-badge[data-risk='medium'] {
+  background-color: #fef3c7;
+  border-color: #fbbf24;
+  color: #78350f;
+}
+
+.ps-risk-badge[data-risk='low'] {
+  background-color: #dcfce7;
+  border-color: #34d399;
+  color: #065f46;
+}
+
+.ps-risk-badge[data-risk='unknown'] {
+  background-color: #e0e7ff;
+  border-color: #818cf8;
+  color: #3730a3;
+}
+
+.ps-panel-container {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 2147483647;
+  width: min(360px, 85vw);
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
+  border-radius: 16px;
+  overflow: hidden;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  transform: translateY(120%);
+  transition: transform 0.25s ease;
+}
+
+.ps-panel-container[data-open='true'] {
+  transform: translateY(0);
+}
+
+.ps-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: linear-gradient(120deg, #2563eb, #7c3aed);
+  color: #fff;
+}
+
+.ps-panel-body {
+  padding: 16px;
+  color: #1f2933;
+  line-height: 1.5;
+}
+
+.ps-panel-title {
+  font-size: 14px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.ps-panel-close {
+  background: rgba(255, 255, 255, 0.15);
+  border: none;
+  color: inherit;
+  border-radius: 999px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.ps-panel-metadata {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+  font-size: 13px;
+}
+
+.ps-panel-metadata strong {
+  display: inline-block;
+  min-width: 72px;
+}
+
+.ps-muted {
+  color: #6b7280;
+}

--- a/packages/browser-extension/src/content/web.ts
+++ b/packages/browser-extension/src/content/web.ts
@@ -1,0 +1,3 @@
+import { startLinkScanner } from './linkHighlighter';
+
+startLinkScanner();

--- a/packages/browser-extension/src/env.d.ts
+++ b/packages/browser-extension/src/env.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="vite/client" />
+
+declare const __TARGET__: 'chrome' | 'firefox';
+
+declare interface ImportMetaEnv {
+  readonly VITE_API_ENDPOINT?: string;
+  readonly VITE_API_TOKEN?: string;
+  readonly VITE_API_TIMEOUT_MS?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/browser-extension/tsconfig.json
+++ b/packages/browser-extension/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["chrome"],
+    "resolveJsonModule": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/browser-extension/vite.config.ts
+++ b/packages/browser-extension/vite.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig } from 'vite';
+import path from 'node:path';
+import fs from 'node:fs';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+const target = process.env.TARGET === 'firefox' ? 'firefox' : 'chrome';
+const manifestPath = path.resolve(__dirname, `manifest.${target}.json`);
+
+if (!fs.existsSync(manifestPath)) {
+  throw new Error(`Manifest file not found for target: ${target}`);
+}
+
+export default defineConfig({
+  build: {
+    outDir: path.resolve(__dirname, 'dist', target),
+    emptyOutDir: true,
+    sourcemap: true,
+    rollupOptions: {
+      input: {
+        'background/index': path.resolve(__dirname, 'src/background/index.ts'),
+        'content/gmail': path.resolve(__dirname, 'src/content/gmail.ts'),
+        'content/social': path.resolve(__dirname, 'src/content/social.ts'),
+        'content/web': path.resolve(__dirname, 'src/content/web.ts'),
+      },
+      output: {
+        entryFileNames: (chunk) => `${chunk.name}.js`,
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        assetFileNames: 'assets/[name]-[hash][extname]',
+      },
+    },
+  },
+  define: {
+    __TARGET__: JSON.stringify(target),
+  },
+  plugins: [
+    viteStaticCopy({
+      targets: [
+        {
+          src: manifestPath,
+          dest: '.',
+          rename: 'manifest.json',
+        },
+      ],
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary
- scaffold a TypeScript/Vite MV3 extension with environment-aware background worker for API-driven URL scanning
- add Gmail, social, and generic content scripts that flag links, render risk badges, and open a details panel
- provide build targets, lint/typecheck scripts, and manual QA checklist for Chrome and Firefox bundles

## Testing
- node packages/browser-extension/scripts/manual-qa.js | head

------
https://chatgpt.com/codex/tasks/task_e_68e4a692c1408327ab6c0963e3c667fc